### PR TITLE
provide default session using force_close=True parameter

### DIFF
--- a/pyoctoprintapi/api.py
+++ b/pyoctoprintapi/api.py
@@ -35,7 +35,6 @@ class OctoprintApi:
 
     async def get_printer_info(self):
         _LOGGER.debug("Request Method=GET Endpoint=%s", PRINTER_ENDPOINT)
-        await asyncio.sleep(0.001)
         response = await self._session.get(self._base_url + PRINTER_ENDPOINT, headers=self._headers)
         if response.status == 409:
             raise PrinterOffline("Printer is not operational")
@@ -58,7 +57,6 @@ class OctoprintApi:
 
     async def check_appkeys_enabled(self):
         _LOGGER.debug("Request Method=GET Endpoint=%s", APPKEY_PROBE_ENDPOINT)
-        await asyncio.sleep(0.001)
         response = await self._session.get(self._base_url + APPKEY_PROBE_ENDPOINT)
         if response.status != 204:
             return False
@@ -70,7 +68,6 @@ class OctoprintApi:
         if user:
             data["user"] = user
         _LOGGER.debug("Request Method=GET Endpoint=%s", APPKEY_REQUEST_ENDPOINT)
-        await asyncio.sleep(0.001)
         response = await self._session.post(self._base_url + APPKEY_REQUEST_ENDPOINT, json = data)
         if response.status == 201:
             location_url = response.headers["Location"]
@@ -80,7 +77,6 @@ class OctoprintApi:
 
     async def appkeys_check_status(self, appkey:str):
         _LOGGER.debug("Request Method=GET Endpoint=%s", APPKEY_REQUEST_ENDPOINT)
-        await asyncio.sleep(0.001)
         response = await self._session.get(f"{self._base_url}{APPKEY_REQUEST_ENDPOINT}/{appkey}")
         if response.status == 404:
             raise ApiError("Application key creation request has been denied or timed out")
@@ -91,7 +87,6 @@ class OctoprintApi:
     async def issue_system_command(self, source:str, action:str) -> None:
         _LOGGER.debug("Request Method=POST Endpoint=%s", SYSTEM_COMMAND_ENDPOINT)
         url = f"{self._base_url}{SYSTEM_COMMAND_ENDPOINT}/{source}/{action}"
-        await asyncio.sleep(0.001)
         response = await self._session.post(url, headers=self._headers)
         if response.status != 204:
             raise ApiError(f"Failed to issue command {source}.{action} - code {response.status}")
@@ -140,7 +135,6 @@ class OctoprintApi:
 
     async def _get_request(self, endpoint: str):
         _LOGGER.debug("Request Method=GET Endpoint=%s", endpoint)
-        await asyncio.sleep(0.001)
         response = await self._session.get(self._base_url + endpoint, headers=self._headers)
         try:
             response.raise_for_status()

--- a/pyoctoprintapi/octoprint_client.py
+++ b/pyoctoprintapi/octoprint_client.py
@@ -20,9 +20,12 @@ _LOGGER = logging.getLogger(__name__)
 
 class OctoprintClient:
     """Client for interacting with an Octoprint server"""
-    def __init__(self, host: str, session: aiohttp.ClientSession, port: int = 80, ssl: bool = False, path: str = "/"):
+    def __init__(self, host: str, session: aiohttp.ClientSession = None, port: int = 80, ssl: bool = False, path: str = "/"):
         protocol = "https" if ssl else "http"
         self._base_url = f"{protocol}://{host}:{port}{path}"
+        if session is None:
+            connector = aiohttp.TCPConnector(force_close=True)
+            session = aiohttp.ClientSession(connector=connector)
         self._api = OctoprintApi(self._base_url, session)
 
     async def request_app_key(self, app_name: str, user:str, timeout:int = 5) -> str:


### PR DESCRIPTION
This PR adds a default session to the library, to provide consumers with a sensible default.
Since the default session also uses the `force_close=True` option on the `TCPConnector`, the artificial delays introduced in [57350e88](https://github.com/rfleming71/pyoctoprintapi/commit/57350e887b1d18d62026a7bac6f493c6a8f72692) are not necessary anymore.

This PR is meant to help fix these other issues:
https://github.com/OctoPrint/OctoPrint/issues/4764
https://github.com/home-assistant/core/issues/83624
And will be used in this PR:
https://github.com/home-assistant/core/pull/90001