### PR TITLE
Support WebRTC camera stream URLs

### DIFF
--- a/pyoctoprintapi/settings.py
+++ b/pyoctoprintapi/settings.py
@@ -83,7 +83,10 @@ class WebcamSettings:
     @property
     def stream_url(self) -> str:
         stream_url = self._raw["streamUrl"]
-        if stream_url[:4] == "http":
+        if (stream_url.startswith("http://")
+                or stream_url.startswith("https://")
+                or stream_url.startswith("webrtc://")
+                or stream_url.startswith("webrtcs://")):
             return stream_url
             
         if stream_url[:1] == "/" and self._base_url[-1:] == "/":

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -143,3 +143,26 @@ TEST_SETTINGS_CAMERA_1 = """
    "webcamEnabled": true
 }
 """
+
+# go2rtc style
+TEST_SETTINGS_CAMERA_2 = """
+{
+   "bitrate": "10000k",
+   "cacheBuster": false,
+   "ffmpegPath": "/usr/bin/ffmpeg",
+   "ffmpegThreads": 1,
+   "ffmpegVideoCodec": "libx264",
+   "flipH": false,
+   "flipV": false,
+   "rotate90": false,
+   "snapshotSslValidation": true,
+   "snapshotTimeout": 5,
+   "snapshotUrl": "http://127.0.0.1:1984/api/frame.jpeg?src=streamname",
+   "streamRatio": "16:9",
+   "streamTimeout": 5,
+   "streamUrl": "webrtc://127.0.0.1:1984/api/webrtc?src=streamname",
+   "timelapseEnabled": true,
+   "watermark": true,
+   "webcamEnabled": true
+}
+"""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,8 @@
 import json
 
 from pyoctoprintapi.settings import TrackingSetting, WebcamSettings, DiscoverySettings
-from fixtures import TEST_SETTINGS_CAMERA, TEST_SETTINGS_CAMERA_1, TEST_SETTINGS_TRACKING, TEST_SETTINGS_DISCOVERY
+from fixtures import (TEST_SETTINGS_CAMERA, TEST_SETTINGS_CAMERA_1,TEST_SETTINGS_CAMERA_2, TEST_SETTINGS_TRACKING,
+                      TEST_SETTINGS_DISCOVERY)
 
 def test_tracking_setting_properties():
     tracking = TrackingSetting(json.loads(TEST_SETTINGS_TRACKING))
@@ -24,16 +25,16 @@ def test_webcam_settings_properties():
     assert tracking.external_snapshot_url == "https://foo.com:8080/webcam/?action=snapshot"
     assert tracking.stream_url == "https://foo.com:8080/webcam/?action=stream"
 
-def test_webcam_settings_2_properties():
-    tracking = WebcamSettings("https://foo.com:8080", json.loads(TEST_SETTINGS_CAMERA))
-    assert tracking.enabled 
-    assert tracking.bitrate == "10000k"
-    assert tracking.external_snapshot_url == "https://foo.com:8080/webcam/?action=snapshot"
-    assert tracking.stream_url == "https://foo.com:8080/webcam/?action=stream"
-
-def test_webcam_settings_2_properties():
+def test_webcam_settings_1_properties():
     tracking = WebcamSettings("https://foo.com:8080", json.loads(TEST_SETTINGS_CAMERA_1))
     assert tracking.enabled 
     assert tracking.bitrate == "10000k"
     assert tracking.external_snapshot_url == "http://127.0.0.1:8000/webcam/?action=snapshot"
     assert tracking.stream_url == "http://127.0.0.1:8000/webcam/?action=stream"
+
+def test_webcam_settings_2_properties():
+    tracking = WebcamSettings("https://foo.com:8080", json.loads(TEST_SETTINGS_CAMERA_2))
+    assert tracking.enabled 
+    assert tracking.bitrate == "10000k"
+    assert tracking.internal_snapshot_url == "http://127.0.0.1:1984/api/frame.jpeg?src=streamname"
+    assert tracking.stream_url == "webrtc://127.0.0.1:1984/api/webrtc?src=streamname"


### PR DESCRIPTION
Fixes #12 by adding support for absolute `webrtc(s)://` camera stream URLs.